### PR TITLE
Run idea simulation e2e

### DIFF
--- a/docs/idea-execution-report.md
+++ b/docs/idea-execution-report.md
@@ -1,0 +1,7 @@
+# Idea Execution Report
+
+- **chatlog-parser-feature**: pass ([yaml](../ideas/chatlog-parser-feature.idea.yaml), [log](../logs/idea-runtime/chatlog-parser-feature.json))
+- **conversation-log-router**: pass ([yaml](../ideas/conversation-log-router.idea.yaml), [log](../logs/idea-runtime/conversation-log-router.json))
+- **documentation-system-consolidation**: pass ([yaml](../ideas/documentation-system-consolidation.idea.yaml), [log](../logs/idea-runtime/documentation-system-consolidation.json))
+- **logging-traceability-plan**: pass ([yaml](../ideas/logging-traceability-plan.idea.yaml), [log](../logs/idea-runtime/logging-traceability-plan.json))
+- **unified-migration-system**: pass ([yaml](../ideas/unified-migration-system.idea.yaml), [log](../logs/idea-runtime/unified-migration-system.json))

--- a/docs/ideas/chatlog-parser-feature-execution.md
+++ b/docs/ideas/chatlog-parser-feature-execution.md
@@ -1,0 +1,12 @@
+# Chatlog Parser Feature Execution
+
+**Idea file**: [/workspace/ai-kernel/ideas/chatlog-parser-feature.idea.yaml](../../ideas/chatlog-parser-feature.idea.yaml)
+**Log file**: [../../logs/idea-runtime/chatlog-parser-feature.json](../../logs/idea-runtime/chatlog-parser-feature.json)
+
+## Output
+
+{"llm_output":"SIMULATED OUTPUT","tokens":0,"provider":"none"}
+
+## Agents / Followups
+
+chatlog-parser

--- a/docs/ideas/conversation-log-router-execution.md
+++ b/docs/ideas/conversation-log-router-execution.md
@@ -1,0 +1,12 @@
+# Automation & Validation Conversation Log Execution
+
+**Idea file**: [/workspace/ai-kernel/ideas/conversation-log-router.idea.yaml](../../ideas/conversation-log-router.idea.yaml)
+**Log file**: [../../logs/idea-runtime/conversation-log-router.json](../../logs/idea-runtime/conversation-log-router.json)
+
+## Output
+
+{"llm_output":"SIMULATED OUTPUT","tokens":0,"provider":"none"}
+
+## Agents / Followups
+
+log-orchestrator

--- a/docs/ideas/documentation-system-consolidation-execution.md
+++ b/docs/ideas/documentation-system-consolidation-execution.md
@@ -1,0 +1,12 @@
+# Documentation System Consolidation Execution
+
+**Idea file**: [/workspace/ai-kernel/ideas/documentation-system-consolidation.idea.yaml](../../ideas/documentation-system-consolidation.idea.yaml)
+**Log file**: [../../logs/idea-runtime/documentation-system-consolidation.json](../../logs/idea-runtime/documentation-system-consolidation.json)
+
+## Output
+
+{"llm_output":"SIMULATED OUTPUT","tokens":0,"provider":"none"}
+
+## Agents / Followups
+
+documentation-orchestrator

--- a/docs/ideas/logging-traceability-plan-execution.md
+++ b/docs/ideas/logging-traceability-plan-execution.md
@@ -1,0 +1,12 @@
+# Logging & Traceability Plan Execution
+
+**Idea file**: [/workspace/ai-kernel/ideas/logging-traceability-plan.idea.yaml](../../ideas/logging-traceability-plan.idea.yaml)
+**Log file**: [../../logs/idea-runtime/logging-traceability-plan.json](../../logs/idea-runtime/logging-traceability-plan.json)
+
+## Output
+
+{"llm_output":"SIMULATED OUTPUT","tokens":0,"provider":"none"}
+
+## Agents / Followups
+
+log-orchestrator

--- a/docs/ideas/unified-migration-system-execution.md
+++ b/docs/ideas/unified-migration-system-execution.md
@@ -1,0 +1,12 @@
+# Unified Migration and Document Processing System Execution
+
+**Idea file**: [/workspace/ai-kernel/ideas/unified-migration-system.idea.yaml](../../ideas/unified-migration-system.idea.yaml)
+**Log file**: [../../logs/idea-runtime/unified-migration-system.json](../../logs/idea-runtime/unified-migration-system.json)
+
+## Output
+
+{"llm_output":"SIMULATED OUTPUT","tokens":0,"provider":"none"}
+
+## Agents / Followups
+
+unified-migration-orchestrator

--- a/logs/idea-e2e-status.json
+++ b/logs/idea-e2e-status.json
@@ -1,0 +1,7 @@
+{
+  "chatlog-parser-feature": "pass",
+  "conversation-log-router": "pass",
+  "documentation-system-consolidation": "pass",
+  "logging-traceability-plan": "pass",
+  "unified-migration-system": "pass"
+}

--- a/logs/idea-runtime/chatlog-parser-feature.json
+++ b/logs/idea-runtime/chatlog-parser-feature.json
@@ -1,0 +1,7 @@
+{
+  "title": "Chatlog Parser Feature",
+  "executed_at": "2025-06-10T02:29:08.107Z",
+  "result": "{\"llm_output\":\"SIMULATED OUTPUT\",\"tokens\":0,\"provider\":\"none\"}",
+  "provider": "none",
+  "input_summary": "INTERNAL INJECTED PROMPT:\nParses exported chat logs to cluster ideas and generate Markdown docs with"
+}

--- a/logs/idea-runtime/conversation-log-router.json
+++ b/logs/idea-runtime/conversation-log-router.json
@@ -1,0 +1,7 @@
+{
+  "title": "Automation & Validation Conversation Log",
+  "executed_at": "2025-06-10T02:29:08.234Z",
+  "result": "{\"llm_output\":\"SIMULATED OUTPUT\",\"tokens\":0,\"provider\":\"none\"}",
+  "provider": "none",
+  "input_summary": "INTERNAL INJECTED PROMPT:\nPersistent log capturing validation, fixing, and migration events with lin"
+}

--- a/logs/idea-runtime/documentation-system-consolidation.json
+++ b/logs/idea-runtime/documentation-system-consolidation.json
@@ -1,0 +1,7 @@
+{
+  "title": "Documentation System Consolidation",
+  "executed_at": "2025-06-10T02:29:08.371Z",
+  "result": "{\"llm_output\":\"SIMULATED OUTPUT\",\"tokens\":0,\"provider\":\"none\"}",
+  "provider": "none",
+  "input_summary": "INTERNAL INJECTED PROMPT:\nPlan to merge multiple documentation orchestrators into a single source of"
+}

--- a/logs/idea-runtime/logging-traceability-plan.json
+++ b/logs/idea-runtime/logging-traceability-plan.json
@@ -1,0 +1,7 @@
+{
+  "title": "Logging & Traceability Plan",
+  "executed_at": "2025-06-10T02:29:08.511Z",
+  "result": "{\"llm_output\":\"SIMULATED OUTPUT\",\"tokens\":0,\"provider\":\"none\"}",
+  "provider": "none",
+  "input_summary": "INTERNAL INJECTED PROMPT:\nStandards for JSON logs and feedback automation in Clarity Engine."
+}

--- a/logs/idea-runtime/unified-migration-system.json
+++ b/logs/idea-runtime/unified-migration-system.json
@@ -1,0 +1,7 @@
+{
+  "title": "Unified Migration and Document Processing System",
+  "executed_at": "2025-06-10T02:29:08.722Z",
+  "result": "{\"llm_output\":\"SIMULATED OUTPUT\",\"tokens\":0,\"provider\":\"none\"}",
+  "provider": "none",
+  "input_summary": "INTERNAL INJECTED PROMPT:\nFinalization plan to consolidate scripts into a safe migration system with"
+}

--- a/scripts/core/provider-router.js
+++ b/scripts/core/provider-router.js
@@ -147,7 +147,13 @@ class ProviderRouter {
   async route(agentName, prompt, agentConfig = {}, options = {}) {
     const provider = options.provider || this.getProvider(agentName, agentConfig);
     let result;
-    if (provider === 'anthropic') {
+    if (provider === 'none' || process.env.SIMULATE === 'true') {
+      result = {
+        text: JSON.stringify({ llm_output: 'SIMULATED OUTPUT', tokens: 0, provider: 'none' }),
+        model: 'simulation',
+        endpoint: 'simulation'
+      };
+    } else if (provider === 'anthropic') {
       result = await this.callAnthropic(prompt, options.model);
     } else if (provider === 'local') {
       result = this.callLocal(prompt, options.model);
@@ -155,7 +161,7 @@ class ProviderRouter {
       result = await this.callOpenAI(prompt, options.model);
     }
     this.logUsage(agentName, provider, result.model, result.endpoint);
-    const keySource = provider === 'local' ? 'n/a' : (process.env.USE_BYOK === 'true' ? 'byok' : 'hosted');
+    const keySource = provider === 'local' || provider === 'none' ? 'n/a' : (process.env.USE_BYOK === 'true' ? 'byok' : 'hosted');
     this.logActivity(agentName, provider, result.model, result.endpoint, keySource);
     return result.text;
   }

--- a/scripts/idea-runner.js
+++ b/scripts/idea-runner.js
@@ -32,12 +32,21 @@ async function runIdea(ideaPath, origin = 'cli') {
   const runtimeDir = path.join(repoRoot, 'logs', 'idea-runtime');
   fs.mkdirSync(runtimeDir, { recursive: true });
   const runtimePath = path.join(runtimeDir, `${slug}.json`);
-  fs.writeFileSync(runtimePath, JSON.stringify({ timestamp: new Date().toISOString(), output }, null, 2));
+  const runtimeData = {
+    title: idea.title || slug,
+    executed_at: new Date().toISOString(),
+    result: output,
+    provider: router.getProvider(slug, { provider }),
+    input_summary: prompt.slice(0, 100)
+  };
+  fs.writeFileSync(runtimePath, JSON.stringify(runtimeData, null, 2));
 
   const docsDir = path.join(repoRoot, 'docs', 'ideas');
   fs.mkdirSync(docsDir, { recursive: true });
   const docPath = path.join(docsDir, `${slug}-execution.md`);
-  const md = `# ${idea.title || slug} Execution\n\n**Idea file**: ${ideaPath}\n\n## Output\n\n\n${output}\n`;
+  const relYaml = path.relative(docsDir, abs).replace(/\\/g, '/');
+  const relLog = path.relative(docsDir, runtimePath).replace(/\\/g, '/');
+  const md = `# ${idea.title || slug} Execution\n\n**Idea file**: [${ideaPath}](${relYaml})\n**Log file**: [${relLog}](${relLog})\n\n## Output\n\n${output}\n\n## Agents / Followups\n\n${idea.agents_required || 'None'}\n`;
   fs.writeFileSync(docPath, md);
 
   const summaryFile = path.join(repoRoot, 'logs', 'prompt-routing-summary.json');

--- a/scripts/run-idea-e2e.js
+++ b/scripts/run-idea-e2e.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const ideaDir = path.join(repoRoot, 'ideas');
+const ideaFiles = fs
+  .readdirSync(ideaDir)
+  .filter(f => f.endsWith('.idea.yaml'))
+  .map(f => path.join(ideaDir, f));
+const status = {};
+
+for (const file of ideaFiles) {
+  const slug = path.basename(file, '.idea.yaml');
+  const res = spawnSync('node', ['kernel-cli.js', 'run-idea', file, '--use-byok'], {
+    cwd: repoRoot,
+    env: { ...process.env, PROVIDER: 'none', SIMULATE: 'true' },
+    stdio: 'inherit'
+  });
+
+  const runtimePath = path.join(repoRoot, 'logs', 'idea-runtime', `${slug}.json`);
+  let passed = false;
+  if (fs.existsSync(runtimePath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(runtimePath, 'utf8'));
+      passed = Boolean(data.title && data.executed_at && data.result && data.provider && data.input_summary);
+    } catch {}
+  }
+  status[slug] = passed ? 'pass' : 'fail';
+}
+
+fs.writeFileSync(path.join(repoRoot, 'logs', 'idea-e2e-status.json'), JSON.stringify(status, null, 2));
+
+let md = '# Idea Execution Report\n\n';
+for (const file of ideaFiles) {
+  const slug = path.basename(file, '.idea.yaml');
+  const yamlRel = path.relative(path.join(repoRoot, 'docs'), file).replace(/\\/g, '/');
+  const logRel = path.relative(path.join(repoRoot, 'docs'), path.join(repoRoot, 'logs', 'idea-runtime', `${slug}.json`)).replace(/\\/g, '/');
+  md += `- **${slug}**: ${status[slug]} ([yaml](${yamlRel}), [log](${logRel}))\n`;
+}
+fs.writeFileSync(path.join(repoRoot, 'docs', 'idea-execution-report.md'), md);


### PR DESCRIPTION
## Summary
- extend provider router with simulation mode
- enhance idea runner logging
- add script to run idea e2e tests
- execute sample ideas and record results

## Testing
- `npm test`
- `node scripts/run-idea-e2e.js`

------
https://chatgpt.com/codex/tasks/task_e_684797cc0d8483279e9ef728cf6a609b