### PR TITLE
Implement idea runtime approval workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ ai-kernel-slim.zip
 .runtime/
 .temp/
 scripts/internal/prompt-injector.js
+runtime/
+approved/
+build/

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,13 @@ standards:
 	make -C kernel-slate standards
 
 release-check:
-	make -C kernel-slate release-check
+        make -C kernel-slate release-check
+
+run-ideas:
+        node scripts/run-idea-e2e.js
+
+promote-idea:
+        node kernel-cli.js promote-idea $(slug)
+
+export-approved:
+        node scripts/export-approved.js

--- a/kernel-cli.js
+++ b/kernel-cli.js
@@ -46,13 +46,31 @@ try {
 } catch {}
 async function runIdeaCli() {
   const { runIdea } = require('./scripts/idea-runner');
-  const ideaPath = args[0];
-  if (!ideaPath) {
-    console.log('Usage: run-idea <path/to/idea.yaml>');
+  const target = args[0];
+  if (!target) {
+    console.log('Usage: run-idea <slug|path>');
     process.exit(1);
   }
   try {
-    await runIdea(ideaPath, 'cli');
+    const res = await runIdea(target, 'cli');
+    if (res && res.success) {
+      console.log(`Run complete. Promote with: node kernel-cli.js promote-idea ${res.slug}`);
+    }
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+function promoteIdeaCli() {
+  const { promoteIdea } = require('./scripts/promote-idea');
+  const slug = args[0];
+  if (!slug) {
+    console.log('Usage: promote-idea <slug>');
+    process.exit(1);
+  }
+  try {
+    promoteIdea(slug);
   } catch (err) {
     console.error(err.message);
     process.exit(1);
@@ -63,6 +81,8 @@ if (cmd === 'ignite') {
   ignite();
 } else if (cmd === 'run-idea') {
   runIdeaCli();
+} else if (cmd === 'promote-idea') {
+  promoteIdeaCli();
 } else if (fs.existsSync(slateCli)) {
   const res = spawnSync('node', [slateCli, cmd, ...args], { cwd: repoRoot, stdio: 'inherit' });
   process.exit(res.status);

--- a/scripts/export-approved.js
+++ b/scripts/export-approved.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function exportApproved() {
+  const repoRoot = path.resolve(__dirname, '..');
+  const approvedDir = path.join(repoRoot, 'approved', 'ideas');
+  if (!fs.existsSync(approvedDir)) return;
+  const buildDir = path.join(repoRoot, 'build', 'approved-ideas');
+  fs.mkdirSync(buildDir, { recursive: true });
+  const files = fs.readdirSync(approvedDir).filter(f => f.endsWith('.idea.yaml'));
+  for (const file of files) {
+    const slug = path.basename(file, '.idea.yaml');
+    const idea = path.join(approvedDir, file);
+    const log = path.join(repoRoot, 'logs', 'approved-runtime', `${slug}.json`);
+    const summary = path.join(repoRoot, 'docs', 'approved', `${slug}.md`);
+    const exec = path.join(repoRoot, 'docs', 'ideas', `${slug}-execution.md`);
+    const zipPath = path.join(buildDir, `${slug}.idea.zip`);
+    const args = ['-j', zipPath, idea];
+    [log, summary, exec].forEach(p => { if (fs.existsSync(p)) args.push(p); });
+    spawnSync('zip', args, { cwd: repoRoot, stdio: 'inherit' });
+  }
+}
+
+if (require.main === module) exportApproved();
+
+module.exports = { exportApproved };

--- a/scripts/idea-runner.js
+++ b/scripts/idea-runner.js
@@ -15,10 +15,16 @@ function loadInjector() {
   }
 }
 
-async function runIdea(ideaPath, origin = 'cli') {
+async function runIdea(input, origin = 'cli') {
   const repoRoot = path.resolve(__dirname, '..');
-  const abs = path.resolve(repoRoot, ideaPath);
+  let abs;
+  if (input.endsWith('.idea.yaml') || input.includes('/')) {
+    abs = path.resolve(repoRoot, input);
+  } else {
+    abs = path.join(repoRoot, 'runtime', 'ideas', `${input}.idea.yaml`);
+  }
   if (!fs.existsSync(abs)) throw new Error('Idea file not found');
+  const ideaPath = path.relative(repoRoot, abs);
   const idea = yaml.load(fs.readFileSync(abs, 'utf8')) || {};
   const slug = slugify(path.basename(abs, '.idea.yaml'));
   const injector = loadInjector();
@@ -58,7 +64,8 @@ async function runIdea(ideaPath, origin = 'cli') {
   arr.push({ timestamp: new Date().toISOString(), ideaPath, provider: router.getProvider(slug, { provider }), tokens, origin });
   fs.writeFileSync(summaryFile, JSON.stringify(arr, null, 2));
 
-  return { output, slug };
+  const success = Boolean(output);
+  return { output, slug, success };
 }
 
 module.exports = { runIdea };

--- a/scripts/promote-idea.js
+++ b/scripts/promote-idea.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline-sync');
+
+function promoteIdea(slug) {
+  const repoRoot = path.resolve(__dirname, '..');
+  const srcIdea = path.join(repoRoot, 'runtime', 'ideas', `${slug}.idea.yaml`);
+  const dstIdea = path.join(repoRoot, 'approved', 'ideas', `${slug}.idea.yaml`);
+  const srcLog = path.join(repoRoot, 'logs', 'idea-runtime', `${slug}.json`);
+  const dstLog = path.join(repoRoot, 'logs', 'approved-runtime', `${slug}.json`);
+  const srcDoc = path.join(repoRoot, 'docs', 'ideas', `${slug}.md`);
+  const dstDoc = path.join(repoRoot, 'docs', 'approved', `${slug}.md`);
+  if (!fs.existsSync(srcIdea) || !fs.existsSync(srcLog) || !fs.existsSync(srcDoc)) {
+    throw new Error('Required files missing for promotion');
+  }
+  if (fs.existsSync(dstIdea)) {
+    const ans = readline.question('Approved idea exists. Overwrite? [y/N] ');
+    if (ans.toLowerCase() !== 'y') return;
+  }
+  fs.mkdirSync(path.dirname(dstIdea), { recursive: true });
+  fs.mkdirSync(path.dirname(dstLog), { recursive: true });
+  fs.mkdirSync(path.dirname(dstDoc), { recursive: true });
+  fs.renameSync(srcIdea, dstIdea);
+  fs.renameSync(srcLog, dstLog);
+  fs.renameSync(srcDoc, dstDoc);
+  const logFile = path.join(repoRoot, 'logs', 'idea-promotion.json');
+  let arr = [];
+  if (fs.existsSync(logFile)) {
+    try { arr = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {}
+  }
+  arr.push({ slug, promoted_at: new Date().toISOString() });
+  fs.writeFileSync(logFile, JSON.stringify(arr, null, 2));
+}
+
+module.exports = { promoteIdea };


### PR DESCRIPTION
## Summary
- manage runtime and approved idea folders via `.gitignore`
- update idea-runner and run-idea-e2e scripts to read from `/runtime/ideas`
- add promotion helper and export script
- extend kernel CLI with `promote-idea` command
- add Makefile targets for running, promoting and exporting ideas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68479b741fd48327a498a7e46a25ee8e