### PR TITLE
Add vault agent build and reflection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,8 @@ deposit:
 	node scripts/vault-cli.js deposit $(username) $(amount)
 
 vault-status:
-	node scripts/vault-cli.js status $(username)
+        node scripts/vault-cli.js status $(username)
+
+go:
+        make vault-status username=$(username)
+        node scripts/go.js $(username)

--- a/docs/VAULT.md
+++ b/docs/VAULT.md
@@ -17,3 +17,23 @@ make vault-status username=matthew
 
 When running `run-idea`, one token is deducted. Execution is blocked if the balance is zero.
 If `--use-byok` is set, API keys are loaded from `vault/<username>/env.json`.
+
+## Agent generation
+
+Turn a promoted idea into a starter agent package:
+
+```bash
+node kernel-cli.js build-agent-from-idea <slug> --user <name>
+```
+
+The archive is saved to `vault/<name>/agents/<slug>.agent.zip` and logged to `logs/agent-builder-log.json`.
+
+## Vault reflection
+
+Analyze your vault usage and get suggestions:
+
+```bash
+node kernel-cli.js reflect-vault --user <name>
+```
+
+Results are written to `docs/vault/<name>-next.md` and `logs/vault-reflection.json`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Welcome to the private ai-kernel runtime.
 - `/api/run` – POST JSON `{ "cmd": "verify" }`
 - `/api/run-idea` – POST JSON `{ "path": "ideas/foo.idea.yaml" }`
   - add `?user=<name>` to charge a vault user
+- `/api/status` – vault stats for a user
 
 ## Idea Summaries
 
@@ -29,3 +30,6 @@ Example idea files live under `ideas/`. Try `unified-migration-system.idea.yaml`
 2. `curl http://localhost:3077/api/keys/status`
 3. `curl -X POST -d '{"cmd":"devkit --use-byok"}' http://localhost:3077/api/run`
 4. `curl -X POST -d '{"path":"ideas/unified-migration-system.idea.yaml"}' http://localhost:3077/api/run-idea`
+5. `make go username=<name>`
+
+User vaults live under `/vault/<name>/`.

--- a/scripts/build-agent-from-idea.js
+++ b/scripts/build-agent-from-idea.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const yaml = require('js-yaml');
+const { spawnSync } = require('child_process');
+const { ensureUser, logUsage } = require('./core/user-vault');
+
+function buildAgentFromIdea(slug, user) {
+  const repoRoot = path.resolve(__dirname, '..');
+  ensureUser(user);
+  const ideaPath = path.join(repoRoot, 'vault', user, 'ideas', `${slug}.idea.yaml`);
+  if (!fs.existsSync(ideaPath)) throw new Error('Idea not found');
+  const idea = yaml.load(fs.readFileSync(ideaPath, 'utf8')) || {};
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-'));
+  const agentYaml = {
+    name: slug,
+    description: idea.title || slug,
+    entry: 'agent.js',
+    version: '0.0.1'
+  };
+  fs.writeFileSync(path.join(tmpDir, 'agent.yaml'), yaml.dump(agentYaml));
+  fs.writeFileSync(
+    path.join(tmpDir, 'agent.js'),
+    "module.exports = async function () {\n  console.log('TODO implement " + slug + "');\n};\n"
+  );
+
+  const readmeSrc = path.join(repoRoot, 'docs', 'ideas', `${slug}.md`);
+  if (fs.existsSync(readmeSrc)) {
+    fs.copyFileSync(readmeSrc, path.join(tmpDir, 'README.md'));
+  }
+
+  const agentsDir = path.join(repoRoot, 'vault', user, 'agents');
+  fs.mkdirSync(agentsDir, { recursive: true });
+  const zipPath = path.join(agentsDir, `${slug}.agent.zip`);
+  spawnSync('zip', ['-j', '-r', zipPath, '.'], { cwd: tmpDir, stdio: 'inherit' });
+
+  const logFile = path.join(repoRoot, 'logs', 'agent-builder-log.json');
+  let arr = [];
+  if (fs.existsSync(logFile)) {
+    try { arr = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {}
+  }
+  arr.push({ timestamp: new Date().toISOString(), user, slug });
+  fs.writeFileSync(logFile, JSON.stringify(arr, null, 2));
+
+  logUsage(user, { timestamp: new Date().toISOString(), action: 'build-agent', slug });
+  return zipPath;
+}
+
+module.exports = { buildAgentFromIdea };

--- a/scripts/go.js
+++ b/scripts/go.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { status, ensureUser } = require('./core/user-vault');
+const { spawnSync } = require('child_process');
+
+const user = process.argv[2];
+if (!user) {
+  console.error('Usage: node scripts/go.js <user>');
+  process.exit(1);
+}
+
+const repoRoot = path.resolve(__dirname, '..');
+ensureUser(user);
+const tokens = status(user).tokens;
+console.log(`Tokens: ${tokens}`);
+if (tokens <= 0) process.exit(0);
+
+const ideaDir = path.join(repoRoot, 'vault', user, 'ideas');
+const files = fs.existsSync(ideaDir) ? fs.readdirSync(ideaDir).filter(f => f.endsWith('.idea.yaml')) : [];
+if (!files.length) process.exit(0);
+files.sort();
+const last = files[files.length - 1].replace('.idea.yaml', '');
+spawnSync('node', ['kernel-cli.js', 'run-idea', last, '--user', user, '--simulate'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+  env: { ...process.env }
+});

--- a/scripts/reflect-vault.js
+++ b/scripts/reflect-vault.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, loadTokens, logUsage } = require('./core/user-vault');
+
+function reflectVault(user) {
+  const repoRoot = path.resolve(__dirname, '..');
+  ensureUser(user);
+  const vaultBase = path.join(repoRoot, 'vault', user);
+  const usagePath = path.join(vaultBase, 'usage.json');
+  const runtimeDir = path.join(repoRoot, 'logs', 'idea-runtime');
+
+  let usage = [];
+  if (fs.existsSync(usagePath)) {
+    try { usage = JSON.parse(fs.readFileSync(usagePath, 'utf8')); } catch {}
+  }
+
+  const lastIdeaEntry = [...usage].reverse().find(u => u.action === 'run-idea');
+  const lastAgentEntry = [...usage].reverse().find(u => u.action && u.action.includes('agent'));
+  const tokens = loadTokens(user);
+
+  let ideaSuggestion = lastIdeaEntry ? path.basename(lastIdeaEntry.idea || '', '.idea.yaml') : null;
+  let agentSuggestion = lastAgentEntry ? lastAgentEntry.slug || lastAgentEntry.agent : null;
+
+  const reflection = {
+    timestamp: new Date().toISOString(),
+    user,
+    tokens,
+    promote_next: ideaSuggestion,
+    fine_tune_agent: agentSuggestion,
+    low_tokens: tokens < 5
+  };
+
+  const logFile = path.join(repoRoot, 'logs', 'vault-reflection.json');
+  let arr = [];
+  if (fs.existsSync(logFile)) {
+    try { arr = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {}
+  }
+  arr.push(reflection);
+  fs.writeFileSync(logFile, JSON.stringify(arr, null, 2));
+
+  const docDir = path.join(repoRoot, 'docs', 'vault');
+  fs.mkdirSync(docDir, { recursive: true });
+  const mdPath = path.join(docDir, `${user}-next.md`);
+  const md = `# Vault Reflection for ${user}\n\n- Tokens: ${tokens}\n- Promote next idea: ${ideaSuggestion || 'n/a'}\n- Agent to fine tune: ${agentSuggestion || 'n/a'}\n- Low tokens: ${reflection.low_tokens ? 'yes' : 'no'}\n`;
+  fs.writeFileSync(mdPath, md);
+
+  logUsage(user, { timestamp: new Date().toISOString(), action: 'reflect-vault' });
+  return reflection;
+}
+
+module.exports = { reflectVault };


### PR DESCRIPTION
## Summary
- add build-agent-from-idea command for quick packaging
- add reflect-vault command for vault suggestions
- expose /api/status endpoint with vault stats
- add go helper and simulate flag in kernel-cli
- document new vault features and update index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a778c7f08327ad69e6b051b121e0