### PR TITLE
Add sanitizer and snapshot tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,13 @@ generate-qr:
 	node kernel-cli.js generate-qr
 
 check-pairing:
-	node kernel-cli.js check-pairing $(id)
+        node kernel-cli.js check-pairing $(id)
+
+sanitize:
+        node kernel-cli.js sanitize
+
+snapshot:
+        node kernel-cli.js snapshot
 
 vault-status:
 	node scripts/vault-cli.js status $(username)

--- a/kernel-cli.js
+++ b/kernel-cli.js
@@ -159,6 +159,24 @@ async function runAgentZipCli() {
   }
 }
 
+async function sanitizeCli() {
+  try {
+    await require('./scripts/orchestration/sanitizer')();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+async function snapshotCli() {
+  try {
+    await require('./scripts/orchestration/snapshot')();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
 if (cmd === 'ignite') {
   ignite();
 } else if (cmd === 'run-idea') {
@@ -175,6 +193,10 @@ if (cmd === 'ignite') {
   checkPairingCli();
 } else if (cmd === 'run-agent') {
   runAgentZipCli();
+} else if (cmd === 'sanitize') {
+  sanitizeCli();
+} else if (cmd === 'snapshot') {
+  snapshotCli();
 } else if (fs.existsSync(slateCli)) {
   const res = spawnSync('node', [slateCli, cmd, ...args], { cwd: repoRoot, stdio: 'inherit' });
   process.exit(res.status);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "glob": "^7.2.3"
   },
   "scripts": {
     "test": "npm install --prefix kernel-slate && npm --prefix kernel-slate test"

--- a/scripts/orchestration/sanitizer.js
+++ b/scripts/orchestration/sanitizer.js
@@ -1,0 +1,80 @@
+const fs = require('fs').promises;
+const path = require('path');
+const glob = require('glob');
+
+function scrub(text) {
+  return text
+    .replace(/\t/g, '  ')
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+    .replace(/\s+$/gm, '');
+}
+
+function sortObject(obj) {
+  return Object.keys(obj)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = obj[key];
+      return acc;
+    }, {});
+}
+
+async function processJson(file, report) {
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const cleaned = scrub(raw);
+    let data = JSON.parse(cleaned);
+    const actions = ['schema check'];
+    if (Array.isArray(data)) {
+      data = data.map(item => {
+        if (typeof item === 'object' && item !== null) {
+          if (!item.timestamp) {
+            item.timestamp = new Date().toISOString();
+          }
+          return sortObject(item);
+        }
+        return item;
+      });
+    } else if (typeof data === 'object') {
+      if (!data.timestamp) data.timestamp = new Date().toISOString();
+      data = sortObject(data);
+    }
+    await fs.writeFile(file, JSON.stringify(data, null, 2) + '\n');
+    report.push({ file, actions });
+  } catch (err) {
+    report.push({ file, error: err.message });
+  }
+}
+
+async function processText(file, report) {
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const cleaned = scrub(raw);
+    await fs.writeFile(file, cleaned + '\n');
+    report.push({ file, actions: ['normalized'] });
+  } catch (err) {
+    report.push({ file, error: err.message });
+  }
+}
+
+async function run() {
+  const base = process.cwd();
+  const report = [];
+  const mdFiles = glob.sync('docs/ideas/*.md', { cwd: base, absolute: true });
+  const jsonFiles = glob.sync('logs/**/*.json', { cwd: base, absolute: true });
+  const vaultJson = glob.sync('vault/*/usage.json', { cwd: base, absolute: true });
+  for (const file of [...mdFiles, ...jsonFiles, ...vaultJson]) {
+    if (file.endsWith('.json')) await processJson(file, report);
+    else await processText(file, report);
+  }
+  await fs.mkdir(path.join(base, 'logs'), { recursive: true });
+  await fs.mkdir(path.join(base, 'docs'), { recursive: true });
+  await fs.writeFile(path.join(base, 'logs', 'sanitizer-report.json'), JSON.stringify(report, null, 2));
+  const summaryMd = ['# Sanitizer Summary', '', ...report.map(r => `- ${path.relative(base, r.file)}: ${r.actions ? r.actions.join(', ') : r.error}`)].join('\n');
+  await fs.writeFile(path.join(base, 'docs', 'sanitizer-summary.md'), summaryMd + '\n');
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = run;

--- a/scripts/orchestration/snapshot.js
+++ b/scripts/orchestration/snapshot.js
@@ -1,0 +1,71 @@
+const fs = require('fs').promises;
+const path = require('path');
+const yaml = require('js-yaml');
+const glob = require('glob');
+
+async function loadMostRecentIdea(base) {
+  const files = glob.sync('ideas/*.idea.yaml', { cwd: base, absolute: true });
+  if (!files.length) return null;
+  let latest = files[0];
+  let mtime = (await fs.stat(latest)).mtimeMs;
+  for (const f of files.slice(1)) {
+    const s = await fs.stat(f);
+    if (s.mtimeMs > mtime) { latest = f; mtime = s.mtimeMs; }
+  }
+  const content = await fs.readFile(latest, 'utf8');
+  return { file: latest, data: yaml.load(content) };
+}
+
+async function loadUsage(base) {
+  const usageFiles = glob.sync('{usage.json,vault/*/usage.json}', { cwd: base, absolute: true });
+  const usage = [];
+  for (const file of usageFiles) {
+    try {
+      const data = JSON.parse(await fs.readFile(file, 'utf8'));
+      usage.push({ file, data });
+    } catch {}
+  }
+  return usage;
+}
+
+async function loadMetadata(base) {
+  const meta = {};
+  for (const file of ['kernel.json', 'installed-agents.json']) {
+    const p = path.join(base, file);
+    if (fs.stat(p).catch(() => false)) {
+      try {
+        meta[file] = JSON.parse(await fs.readFile(p, 'utf8'));
+      } catch {}
+    }
+  }
+  meta.timestamp = new Date().toISOString();
+  return meta;
+}
+
+async function run() {
+  const base = process.cwd();
+  const idea = await loadMostRecentIdea(base);
+  const usage = await loadUsage(base);
+  const metadata = await loadMetadata(base);
+
+  const snapshot = { idea, usage, metadata };
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const slug = idea ? path.basename(idea.file, '.idea.yaml') : 'no-idea';
+  const dir = path.join(base, 'snapshots');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${stamp}-full.json`), JSON.stringify(snapshot, null, 2));
+  const summary = [
+    `# Snapshot Summary for ${slug}`,
+    '',
+    `- Idea: ${idea ? path.relative(base, idea.file) : 'none'}`,
+    `- Usage logs: ${usage.length}`,
+    `- Timestamp: ${metadata.timestamp}`,
+  ].join('\n');
+  await fs.writeFile(path.join(dir, `${slug}.summary.md`), summary + '\n');
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = run;


### PR DESCRIPTION
## Summary
- add sanitizer utility for final runtime
- add snapshot serializer
- wire new utilities into kernel-cli and Makefile
- include glob dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848080fba80832789eddf694f332142