### PR TITLE
Add protocol billing and mobile background sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,16 @@ marketplace:
 	node scripts/marketplace-preview.js
 
 reflect-vault:
-	node kernel-cli.js reflect-vault --user $(user)
+        node kernel-cli.js reflect-vault --user $(user)
+
+sync-vault:
+        node scripts/sync-vault.js $(username)
+
+queue-agent:
+        node kernel-cli.js queue-agent $(path) --user $(user)
+
+run-queue:
+        node kernel-cli.js run-queue --user $(user)
 
 freeze:
         make verify

--- a/docs/AGENT_PROTOCOL.md
+++ b/docs/AGENT_PROTOCOL.md
@@ -1,0 +1,31 @@
+# Agent Protocol
+
+This runtime routes prompts through a token based economy. Each prompt is evaluated by the cost engine and then billed against the user's vault balance.
+
+## Prompt billing flow
+1. `cost-engine.js` estimates tokens for the prompt and applies a 10% protocol markup.
+2. The provider router attempts the preferred provider and falls back to others if needed.
+3. Usage is logged per user in `vault/<user>/usage.json` and global estimates are stored in `logs/prompt-cost-estimates.json`.
+
+## Referral and commission
+- Every user vault contains `settings.json` with `commission_rate` and optional `referrer_id`.
+- When a referred user spends tokens, the referrer earns the configured percentage. Earnings are tracked in `vault/<referrer>/earnings.json`.
+
+## Token tiers
+- `simulated` – 0 tokens
+- `fast` – 1 token
+- `async` – 2 tokens
+- `deep` – 3 tokens
+
+## Agent registry and pricing
+Users can fork agents, set a price, or whitelist buyers in `agent-registry.json`. Prices are denominated in tokens and deducted on execution. Refer to existing Makefile targets to build or run agents.
+
+## Mobile sync
+`make sync-vault username=<user>` updates `vault/<user>/device.json` and records history in `logs/mobile-sync-history.json`.
+
+Background agent queues are managed with:
+```bash
+make queue-agent path=<agent.zip> user=<user>
+make run-queue user=<user>
+```
+Queue results write to `vault/<user>/background-agent-log.json` and `logs/agent-queue-status.json`.

--- a/kernel-cli.js
+++ b/kernel-cli.js
@@ -142,6 +142,37 @@ function checkPairingCli() {
   console.log(checkPair(id) ? 'paired' : 'pending');
 }
 
+function queueAgentCli() {
+  const zip = args[0];
+  if (!zip || !vaultUser) {
+    console.log('Usage: queue-agent <path.zip> --user <user>');
+    process.exit(1);
+  }
+  try {
+    const { queueAgent } = require('./scripts/queue-agent');
+    queueAgent(zip, vaultUser);
+    console.log('queued');
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+async function runQueueCli() {
+  if (!vaultUser) {
+    console.log('Usage: run-queue --user <user>');
+    process.exit(1);
+  }
+  try {
+    const { runQueue } = require('./scripts/run-queue');
+    const out = await runQueue(vaultUser);
+    console.log(JSON.stringify(out, null, 2));
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
 async function runAgentZipCli() {
   const zip = args[0];
   const prompt = args.slice(1).join(' ');
@@ -209,6 +240,10 @@ if (cmd === 'ignite') {
   checkPairingCli();
 } else if (cmd === 'run-agent') {
   runAgentZipCli();
+} else if (cmd === 'queue-agent') {
+  queueAgentCli();
+} else if (cmd === 'run-queue') {
+  runQueueCli();
 } else if (cmd === 'sanitize') {
   sanitizeCli();
 } else if (cmd === 'snapshot') {

--- a/scripts/orchestration/cost-engine.js
+++ b/scripts/orchestration/cost-engine.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+function estimateCost(length, provider = 'openai', context = 4096) {
+  const baseRates = { openai: 0.001, claude: 0.0015, ollama: 0 };
+  const rate = baseRates[provider] || baseRates.openai;
+  const tokens = Math.ceil(length);
+  const cost = tokens * rate;
+  const markup = +(cost * 0.1).toFixed(6);
+  const fallback = provider === 'openai'
+    ? ['openai', 'claude', 'ollama']
+    : provider === 'claude'
+      ? ['claude', 'openai', 'ollama']
+      : ['ollama', 'openai', 'claude'];
+  return { tokens, estimated_cost: cost, provider, fallback, markup, context };
+}
+
+function logEstimate(obj) {
+  const logFile = path.join(__dirname, '..', '..', 'logs', 'prompt-cost-estimates.json');
+  let arr = [];
+  if (fs.existsSync(logFile)) {
+    try { arr = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {}
+  }
+  arr.push(obj);
+  fs.writeFileSync(logFile, JSON.stringify(arr, null, 2));
+}
+
+if (require.main === module) {
+  const argv = require('yargs/yargs')(process.argv.slice(2))
+    .option('length', { type: 'number', demandOption: true })
+    .option('provider', { type: 'string', default: 'openai' })
+    .option('context', { type: 'number', default: 4096 })
+    .argv;
+  const res = estimateCost(argv.length, argv.provider, argv.context);
+  logEstimate({ timestamp: new Date().toISOString(), ...res });
+  console.log(JSON.stringify(res, null, 2));
+}
+
+module.exports = { estimateCost, logEstimate };

--- a/scripts/queue-agent.js
+++ b/scripts/queue-agent.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath } = require('./core/user-vault');
+
+function queueAgent(zipPath, user) {
+  ensureUser(user);
+  const queueFile = path.join(getVaultPath(user), 'agent-queue.json');
+  let arr = [];
+  if (fs.existsSync(queueFile)) {
+    try { arr = JSON.parse(fs.readFileSync(queueFile, 'utf8')); } catch {}
+  }
+  arr.push({ zip: path.resolve(zipPath), timestamp: new Date().toISOString() });
+  fs.writeFileSync(queueFile, JSON.stringify(arr, null, 2));
+
+  const logFile = path.join(__dirname, '..', 'logs', 'agent-queue-status.json');
+  let logArr = [];
+  if (fs.existsSync(logFile)) {
+    try { logArr = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {}
+  }
+  logArr.push({ timestamp: new Date().toISOString(), user, queued: path.basename(zipPath) });
+  fs.writeFileSync(logFile, JSON.stringify(logArr, null, 2));
+}
+
+if (require.main === module) {
+  const [zip, user] = process.argv.slice(2);
+  if (!zip || !user) {
+    console.log('Usage: queue-agent.js <path.zip> <user>');
+    process.exit(1);
+  }
+  queueAgent(zip, user);
+  console.log('queued');
+}
+
+module.exports = { queueAgent };

--- a/scripts/run-queue.js
+++ b/scripts/run-queue.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath, logUsage } = require('./core/user-vault');
+const { runAgentZip } = require('./run-agent-zip');
+
+async function runQueue(user) {
+  ensureUser(user);
+  const queueFile = path.join(getVaultPath(user), 'agent-queue.json');
+  let arr = [];
+  if (fs.existsSync(queueFile)) {
+    try { arr = JSON.parse(fs.readFileSync(queueFile, 'utf8')); } catch {}
+  }
+  const logFile = path.join(getVaultPath(user), 'background-agent-log.json');
+  let logs = [];
+  if (fs.existsSync(logFile)) {
+    try { logs = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {}
+  }
+  const remaining = [];
+  for (const job of arr) {
+    try {
+      const out = await runAgentZip(job.zip, '', user);
+      logs.push({ timestamp: new Date().toISOString(), zip: job.zip, output: out });
+      logUsage(user, { timestamp: new Date().toISOString(), action: 'queue-run', slug: path.basename(job.zip), tokens_used: 1 });
+    } catch (err) {
+      logs.push({ timestamp: new Date().toISOString(), zip: job.zip, error: err.message });
+      remaining.push(job);
+    }
+  }
+  fs.writeFileSync(logFile, JSON.stringify(logs, null, 2));
+  fs.writeFileSync(queueFile, JSON.stringify(remaining, null, 2));
+
+  const statusFile = path.join(__dirname, '..', 'logs', 'agent-queue-status.json');
+  let statusArr = [];
+  if (fs.existsSync(statusFile)) { try { statusArr = JSON.parse(fs.readFileSync(statusFile, 'utf8')); } catch {} }
+  statusArr.push({ timestamp: new Date().toISOString(), user, processed: arr.length });
+  fs.writeFileSync(statusFile, JSON.stringify(statusArr, null, 2));
+  return logs;
+}
+
+if (require.main === module) {
+  const user = process.argv[2];
+  if (!user) { console.log('Usage: run-queue.js <user>'); process.exit(1); }
+  runQueue(user).then(r => console.log(JSON.stringify(r, null, 2))).catch(e => { console.error(e.message); process.exit(1); });
+}
+
+module.exports = { runQueue };

--- a/scripts/sync-vault.js
+++ b/scripts/sync-vault.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath } = require('./core/user-vault');
+
+function syncVault(user) {
+  ensureUser(user);
+  const base = getVaultPath(user);
+  const deviceFile = path.join(base, 'device.json');
+  let data = { qr_uuid: null, geo_tag: null, last_sync: null, os: null };
+  if (fs.existsSync(deviceFile)) {
+    try { data = JSON.parse(fs.readFileSync(deviceFile, 'utf8')); } catch {}
+  }
+  data.last_sync = new Date().toISOString();
+  fs.writeFileSync(deviceFile, JSON.stringify(data, null, 2));
+
+  const logFile = path.join(__dirname, '..', 'logs', 'mobile-sync-history.json');
+  let arr = [];
+  if (fs.existsSync(logFile)) {
+    try { arr = JSON.parse(fs.readFileSync(logFile, 'utf8')); } catch {}
+  }
+  arr.push({ timestamp: data.last_sync, user, os: data.os || null });
+  fs.writeFileSync(logFile, JSON.stringify(arr, null, 2));
+  return data;
+}
+
+if (require.main === module) {
+  const user = process.argv[2];
+  if (!user) {
+    console.log('Usage: sync-vault.js <user>');
+    process.exit(1);
+  }
+  const res = syncVault(user);
+  console.log(JSON.stringify(res, null, 2));
+}
+
+module.exports = { syncVault };


### PR DESCRIPTION
## Summary
- implement a prompt cost engine with fallback estimates
- extend user vault with referral commission settings and earnings log
- add mobile sync and agent queue helpers
- update CLI and Makefile targets for new commands
- document protocol pricing and referral model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480ddf8d3c8327b946ecaa19117c0d