### PR TITLE
Add kernel boot agent and device sync

### DIFF
--- a/docs/AGENT_PROTOCOL.md
+++ b/docs/AGENT_PROTOCOL.md
@@ -22,6 +22,7 @@ Users can fork agents, set a price, or whitelist buyers in `agent-registry.json`
 
 ## Mobile sync
 `make sync-vault username=<user>` updates `vault/<user>/device.json` and records history in `logs/mobile-sync-history.json`.
+Run `node kernel-cli.js sync-device --user <user>` to append device metadata to `vault/<user>/devices.json`.
 
 Background agent queues are managed with:
 ```bash

--- a/scripts/orchestration/kernel-boot.js
+++ b/scripts/orchestration/kernel-boot.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath, loadSettings, loadTokens, logUsage } = require('../core/user-vault');
+const { reflectVault } = require('../reflect-vault');
+const { runIdea } = require('../idea-runner');
+
+function writeJson(file, data) {
+  let arr = [];
+  if (fs.existsSync(file)) {
+    try { arr = JSON.parse(fs.readFileSync(file, 'utf8')); } catch {}
+  }
+  arr.push(data);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(arr, null, 2));
+}
+
+function loadFreePrompts(user) {
+  const file = path.join(getVaultPath(user), 'free_prompts_remaining.json');
+  if (fs.existsSync(file)) {
+    try { return JSON.parse(fs.readFileSync(file, 'utf8')).count || 0; } catch {}
+  }
+  return 0;
+}
+
+function createSummary(user) {
+  const base = getVaultPath(user);
+  const usageFile = path.join(base, 'usage.json');
+  let usage = [];
+  if (fs.existsSync(usageFile)) { try { usage = JSON.parse(fs.readFileSync(usageFile, 'utf8')); } catch {} }
+  const tokens = loadTokens(user);
+  const summary = {
+    timestamp: new Date().toISOString(),
+    tokens,
+    usage_count: usage.length,
+    last_action: usage.length ? usage[usage.length - 1].action : null
+  };
+  fs.writeFileSync(path.join(base, 'daily-summary.json'), JSON.stringify(summary, null, 2));
+  const docDir = path.join(__dirname, '..', '..', 'docs', 'vault');
+  fs.mkdirSync(docDir, { recursive: true });
+  const md = `# Daily Summary for ${user}\n\n- Tokens: ${tokens}\n- Total actions: ${usage.length}\n- Last action: ${summary.last_action || 'n/a'}\n`;
+  fs.writeFileSync(path.join(docDir, `${user}-summary.md`), md);
+}
+
+async function kernelBoot(user) {
+  if (!user) return false;
+  ensureUser(user);
+  const vaultPath = getVaultPath(user);
+  const settingsPath = path.join(vaultPath, 'settings.json');
+  const denialLog = path.join(__dirname, '..', '..', 'logs', 'kernel-boot-denial.json');
+
+  const deny = reason => {
+    console.log('Vault blocked:', reason);
+    writeJson(denialLog, { timestamp: new Date().toISOString(), user, reason });
+  };
+
+  if (!fs.existsSync(settingsPath)) return deny('missing settings.json');
+  const settings = loadSettings(user);
+  const tokens = loadTokens(user);
+  const free = loadFreePrompts(user);
+  if (tokens < 0) return deny('negative token balance');
+  if (tokens === 0 && free <= 0) return deny('no token or free prompts');
+  if (settings.unpaid_balance > 0) return deny('unpaid balance');
+  if (settings.soft_limit && tokens < settings.soft_limit) return deny('soft limit exceeded');
+
+  const reflection = reflectVault(user);
+  if (reflection && reflection.promote_next) {
+    const ideaPath = path.join(vaultPath, 'ideas', `${reflection.promote_next}.idea.yaml`);
+    if (fs.existsSync(ideaPath)) {
+      await runIdea(ideaPath, 'boot', user).catch(err => console.error(err.message));
+    }
+  }
+
+  logUsage(user, { timestamp: new Date().toISOString(), action: 'kernel-boot', tokens_used: 0, remaining_tokens: tokens });
+  createSummary(user);
+  return true;
+}
+
+if (require.main === module) {
+  const user = process.argv[2];
+  kernelBoot(user);
+}
+
+module.exports = kernelBoot;

--- a/scripts/router/prompt-router.js
+++ b/scripts/router/prompt-router.js
@@ -71,7 +71,7 @@ const jobId = Date.now().toString();
 const jobDir = path.join(getVaultPath(user), 'jobs');
 fs.mkdirSync(jobDir, { recursive: true });
 const jobFile = path.join(jobDir, `${jobId}.json`);
-fs.writeFileSync(jobFile, JSON.stringify({ id: jobId, status: 'queued', prompt, tier }, null, 2));
+fs.writeFileSync(jobFile, JSON.stringify({ id: jobId, status: 'queued', prompt, tier, created_at: new Date().toISOString(), delayed: tier === 'deep' || tier === 'async' }, null, 2));
 
 const docsDir = path.join(__dirname, '..', '..', 'docs', 'jobs');
 fs.mkdirSync(docsDir, { recursive: true });

--- a/scripts/run-jobs.js
+++ b/scripts/run-jobs.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const { ProviderRouter } = require('./core/provider-router');
+const { ensureUser, getVaultPath, logUsage, loadTokens, saveTokens } = require('./core/user-vault');
+const { estimateCost } = require('./orchestration/cost-engine');
+
+async function runJobs(user) {
+  ensureUser(user);
+  const base = getVaultPath(user);
+  const jobDir = path.join(base, 'jobs');
+  if (!fs.existsSync(jobDir)) return [];
+  const files = fs.readdirSync(jobDir).filter(f => f.endsWith('.json'));
+  const logs = [];
+  const router = new ProviderRouter();
+
+  for (const f of files) {
+    const p = path.join(jobDir, f);
+    let job = {};
+    try { job = JSON.parse(fs.readFileSync(p, 'utf8')); } catch { continue; }
+    if (job.status !== 'queued') continue;
+    job.status = 'in-progress';
+    fs.writeFileSync(p, JSON.stringify(job, null, 2));
+    const tokensBefore = loadTokens(user);
+    const estimate = estimateCost((job.prompt || '').split(/\s+/).length);
+    if (tokensBefore < estimate.tokens) {
+      job.status = 'failed';
+      job.error = 'insufficient tokens';
+      fs.writeFileSync(p, JSON.stringify(job, null, 2));
+      logs.push({ id: job.id, error: job.error });
+      continue;
+    }
+    saveTokens(user, tokensBefore - estimate.tokens);
+    let output = '';
+    try {
+      output = await router.route('job-' + job.id, job.prompt, {});
+      job.status = 'done';
+      job.output = output;
+    } catch (err) {
+      job.status = 'failed';
+      job.error = err.message;
+    }
+    fs.writeFileSync(p, JSON.stringify(job, null, 2));
+    logUsage(user, { timestamp: new Date().toISOString(), action: 'job-run', id: job.id, tokens_used: estimate.tokens });
+    logs.push({ id: job.id, status: job.status });
+  }
+  return logs;
+}
+
+if (require.main === module) {
+  const user = process.argv[2];
+  runJobs(user).then(r => console.log(JSON.stringify(r, null, 2))).catch(e => { console.error(e); process.exit(1); });
+}
+
+module.exports = { runJobs };

--- a/scripts/sync-device.js
+++ b/scripts/sync-device.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { ensureUser, getVaultPath } = require('./core/user-vault');
+
+function syncDevice(user) {
+  ensureUser(user);
+  const file = path.join(getVaultPath(user), 'devices.json');
+  let arr = [];
+  if (fs.existsSync(file)) {
+    try { arr = JSON.parse(fs.readFileSync(file, 'utf8')); } catch {}
+  }
+  const entry = {
+    timestamp: new Date().toISOString(),
+    hostname: os.hostname(),
+    platform: os.platform(),
+    arch: os.arch()
+  };
+  arr.push(entry);
+  fs.writeFileSync(file, JSON.stringify(arr, null, 2));
+  return entry;
+}
+
+if (require.main === module) {
+  const user = process.argv[2];
+  if (!user) { console.log('Usage: sync-device.js <user>'); process.exit(1); }
+  const out = syncDevice(user);
+  console.log(JSON.stringify(out, null, 2));
+}
+
+module.exports = { syncDevice };


### PR DESCRIPTION
## Summary
- create startup kernel-boot agent
- implement device sync and queued job runner
- wire new commands in `kernel-cli.js`
- document sync-device command
- flag delayed async jobs when queued

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684818f0293c832797a28b53eac3add5