### PR TITLE
Add secure memory diffusion and trust router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,3 +143,22 @@ vault-theme:
 
 self-test-guide:
 node scripts/onboarding/self-test-guide.js $(user)
+
+route:
+node scripts/router/vault-router.js --user $(user) --idea $(idea) --prompt $(prompt) --chatlog $(chatlog)
+
+mask:
+node scripts/agent/mask-prompts.js --file $(file) --prefix
+
+diffuse-vault:
+node scripts/diffuse-memory.js encode --user $(user) --file $(file)
+
+decode-vault:
+node scripts/diffuse-memory.js decode --file $(file)
+
+audit-transmissions:
+node scripts/admin/audit-transmissions.js
+
+admin-decrypt:
+node scripts/admin/admin-decrypt.js --session $(session) --key $(key)
+

--- a/docs/MEMORY_DIFFUSION.md
+++ b/docs/MEMORY_DIFFUSION.md
@@ -1,0 +1,13 @@
+# Memory Diffusion
+
+`diffuse-memory.js` converts vault data into portable artifacts. Encoding a file writes a base64 representation with a `.mp4` extension so it can be streamed or synced between devices. Decoding reverses the process.
+
+Usage:
+
+```bash
+make diffuse-vault user=<id>
+make decode-vault file=<json.mp4>
+```
+
+Events are logged to `vault/<uuid>/diffused-history.json` and `logs/memory-fusion-events.json`.
+

--- a/docs/TRUST_PROTOCOL.md
+++ b/docs/TRUST_PROTOCOL.md
@@ -1,0 +1,12 @@
+# Trust Router Protocol
+
+`vault-router.js` handles encrypted prompt routing. It accepts `.idea.yaml`, `.prompt.json` and `.chatlog.md` files and generates a one time key stored under `keys/<uuid>/<timestamp>.key`.
+
+The router encrypts all files with AES‑256‑GCM and sends only:
+
+```json
+{ encrypted_payload, vault_hash, key_ref, runtime_tag }
+```
+
+Logs are written to `logs/transmission-log.json` and `vault/<uuid>/transmission-history.json`. A copy of each encrypted message is stored under `middle/<uuid>/<timestamp>.json` for later decryption by the vault owner or an admin key.
+

--- a/scripts/admin/admin-decrypt.js
+++ b/scripts/admin/admin-decrypt.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const minimist = require('minimist');
+const argv = minimist(process.argv.slice(2));
+
+const session = argv.session;
+const keyFile = argv.key;
+if (!session || !keyFile) {
+  console.log('Usage: admin-decrypt.js --session <file> --key <keyfile>');
+  process.exit(1);
+}
+
+const data = JSON.parse(fs.readFileSync(session, 'utf8'));
+const key = Buffer.from(fs.readFileSync(keyFile, 'utf8'), 'hex');
+const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(data.iv,'hex'));
+decipher.setAuthTag(Buffer.from(data.auth_tag,'hex'));
+let dec = decipher.update(data.encrypted_payload, 'hex', 'utf8');
+dec += decipher.final('utf8');
+console.log(dec);
+

--- a/scripts/admin/audit-transmissions.js
+++ b/scripts/admin/audit-transmissions.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const logFile = path.join('logs','transmission-log.json');
+if (!fs.existsSync(logFile)) {
+  console.log('No transmissions logged');
+  process.exit(0);
+}
+const data = JSON.parse(fs.readFileSync(logFile,'utf8'));
+console.log(JSON.stringify(data, null, 2));
+

--- a/scripts/agent/mask-prompts.js
+++ b/scripts/agent/mask-prompts.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+const yaml = require('js-yaml');
+
+const argv = minimist(process.argv.slice(2));
+const file = argv.file;
+if (!file) {
+  console.log('Usage: mask-prompts.js --file <input> [--prefix]');
+  process.exit(1);
+}
+
+let text = fs.readFileSync(file, 'utf8');
+
+if (path.extname(file) === '.yaml' || path.extname(file) === '.yml') {
+  try {
+    const data = yaml.load(text);
+    if (data && data.title) delete data.title;
+    text = yaml.dump(data);
+  } catch {}
+}
+
+function mask(t) {
+  t = t.replace(/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g, '[uuid]');
+  t = t.replace(/@[A-Za-z0-9_]+/g, '@user');
+  return t;
+}
+
+let output = mask(text);
+if (argv.prefix) {
+  output = 'You are receiving an encrypted reflection task. Use structure only.\n' + output;
+}
+
+console.log(output);
+

--- a/scripts/diffuse-memory.js
+++ b/scripts/diffuse-memory.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+const { getVaultPath, ensureUser } = require('./core/user-vault');
+
+const argv = minimist(process.argv.slice(2));
+const cmd = argv._[0];
+
+if (!cmd) {
+  console.log('Usage: diffuse-memory.js <encode|decode> [options]');
+  process.exit(1);
+}
+
+if (cmd === 'encode') {
+  const user = argv.user;
+  const file = argv.file;
+  if (!user || !file) {
+    console.log('encode requires --user <id> --file <path>');
+    process.exit(1);
+  }
+  ensureUser(user);
+  const data = fs.readFileSync(file);
+  const b64 = data.toString('base64');
+  const out = file + '.mp4';
+  fs.writeFileSync(out, b64);
+  log(user, { file: path.basename(file), out });
+  console.log(out);
+} else if (cmd === 'decode') {
+  const file = argv.file;
+  if (!file) { console.log('decode requires --file <file>'); process.exit(1); }
+  const b64 = fs.readFileSync(file, 'utf8');
+  const out = file.replace(/\.mp4$/,'');
+  fs.writeFileSync(out, Buffer.from(b64, 'base64'));
+  console.log(out);
+} else {
+  console.log('Unknown command');
+}
+
+function log(user, entry) {
+  const vaultLog = path.join(getVaultPath(user), 'diffused-history.json');
+  const globalLog = path.join('logs', 'memory-fusion-events.json');
+  append(vaultLog, entry);
+  append(globalLog, { user, ...entry });
+}
+
+function append(p, entry) {
+  let arr = [];
+  if (fs.existsSync(p)) { try { arr = JSON.parse(fs.readFileSync(p,'utf8')); } catch {} }
+  arr.push({ timestamp: new Date().toISOString(), ...entry });
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(arr, null, 2));
+}
+

--- a/scripts/promote-scratch.js
+++ b/scripts/promote-scratch.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+const { ensureUser, getVaultPath } = require('./core/user-vault');
+
+const argv = minimist(process.argv.slice(2));
+const user = argv.user || 'default';
+const id = argv.id;
+const confirm = argv.confirm;
+
+if (!id) {
+  console.log('Usage: promote-scratch.js --id <uuid> [--confirm] [--user <u>]');
+  process.exit(1);
+}
+
+ensureUser(user);
+const base = path.join('scratch', id);
+const inputFile = path.join(base, 'input-transcript.json');
+
+if (!fs.existsSync(inputFile)) {
+  console.error('No scratch input for', id);
+  process.exit(1);
+}
+
+const content = fs.readFileSync(inputFile, 'utf8');
+const logEntry = { timestamp: new Date().toISOString(), user, id };
+
+if (confirm) {
+  const vaultDir = getVaultPath(user);
+  const usageFile = path.join(vaultDir, 'usage.json');
+  const promptsFile = path.join(vaultDir, 'prompts.json');
+  let usage = [];
+  let prompts = [];
+  if (fs.existsSync(usageFile)) { try { usage = JSON.parse(fs.readFileSync(usageFile,'utf8')); } catch {} }
+  if (fs.existsSync(promptsFile)) { try { prompts = JSON.parse(fs.readFileSync(promptsFile,'utf8')); } catch {} }
+  usage.push(JSON.parse(content));
+  prompts.push({ id, content: JSON.parse(content) });
+  fs.writeFileSync(usageFile, JSON.stringify(usage, null, 2));
+  fs.writeFileSync(promptsFile, JSON.stringify(prompts, null, 2));
+  logEntry.promoted = true;
+  fs.rmSync(base, { recursive: true, force: true });
+} else {
+  fs.rmSync(base, { recursive: true, force: true });
+  logEntry.promoted = false;
+}
+
+function appendLog(p, entry) {
+  let arr = [];
+  if (fs.existsSync(p)) { try { arr = JSON.parse(fs.readFileSync(p,'utf8')); } catch {} }
+  arr.push(entry);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(arr, null, 2));
+}
+
+appendLog(path.join('logs','scratch-promotions.json'), logEntry);
+

--- a/scripts/router/vault-router.js
+++ b/scripts/router/vault-router.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const minimist = require('minimist');
+const yaml = require('js-yaml');
+const { ensureUser, getVaultPath } = require('../core/user-vault');
+
+const argv = minimist(process.argv.slice(2));
+const user = argv.user || 'default';
+ensureUser(user);
+
+function readFile(file) {
+  if (!file) return null;
+  try { return fs.readFileSync(file, 'utf8'); } catch { return null; }
+}
+
+const ideaFile = argv.idea;
+const promptFile = argv.prompt;
+const chatFile = argv.chatlog;
+const runtimeTag = argv.runtime || 'default-runtime';
+
+const idea = readFile(ideaFile);
+const prompt = readFile(promptFile);
+const chatlog = readFile(chatFile);
+
+const payload = { idea, prompt, chatlog };
+const payloadStr = JSON.stringify(payload);
+
+const key = crypto.randomBytes(32);
+const iv = crypto.randomBytes(16);
+const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+let encrypted = cipher.update(payloadStr, 'utf8', 'hex');
+encrypted += cipher.final('hex');
+const authTag = cipher.getAuthTag().toString('hex');
+
+const keyId = crypto.randomUUID();
+const timestamp = Date.now();
+const keyDir = path.join('keys', keyId);
+fs.mkdirSync(keyDir, { recursive: true });
+fs.writeFileSync(path.join(keyDir, `${timestamp}.key`), key.toString('hex'));
+
+const vaultHash = crypto.createHash('sha256').update(user).digest('hex');
+const message = {
+  encrypted_payload: encrypted,
+  iv: iv.toString('hex'),
+  auth_tag: authTag,
+  vault_hash: vaultHash,
+  key_ref: `${keyId}/${timestamp}.key`,
+  runtime_tag: runtimeTag
+};
+
+console.log(JSON.stringify(message, null, 2));
+
+function appendLog(file, entry) {
+  let arr = [];
+  if (fs.existsSync(file)) {
+    try { arr = JSON.parse(fs.readFileSync(file, 'utf8')); } catch {}
+  }
+  arr.push(entry);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(arr, null, 2));
+}
+
+const logEntry = {
+  timestamp: new Date().toISOString(),
+  user,
+  vault_hash: vaultHash,
+  key_ref: message.key_ref,
+  files: {
+    idea: ideaFile ? path.basename(ideaFile) : null,
+    prompt: promptFile ? path.basename(promptFile) : null,
+    chatlog: chatFile ? path.basename(chatFile) : null
+  }
+};
+
+appendLog(path.join('logs', 'transmission-log.json'), logEntry);
+const userLog = path.join(getVaultPath(user), 'transmission-history.json');
+appendLog(userLog, logEntry);
+
+const middleDir = path.join('middle', user);
+fs.mkdirSync(middleDir, { recursive: true });
+fs.writeFileSync(path.join(middleDir, `${timestamp}.json`), JSON.stringify(message, null, 2));
+


### PR DESCRIPTION
## Summary
- implement `vault-router.js` for encrypted LLM routing with one-time keys
- add prompt masking agent and scratch promotion handler
- add memory diffusion encoder/decoder
- add admin utilities for decrypting and auditing transmissions
- document trust protocol and memory diffusion
- add make targets for route, mask, diffuse and decrypt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487dcecf64832790c9655a7c6183b4