### PR TITLE
Add lightweight local web dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,3 +183,12 @@ node scripts/vault/trace.js seal --file $(file)
 
 trace:
 node scripts/vault/trace.js decode --file $(file)
+
+dashboard:
+NODE_ENV=production node scripts/server/boot-server.js
+
+vault-ui:
+NODE_ENV=production node scripts/server/boot-server.js
+
+reflect-ui:
+NODE_ENV=production node scripts/server/boot-server.js

--- a/docs/DASHBOARD_OVERVIEW.md
+++ b/docs/DASHBOARD_OVERVIEW.md
@@ -1,0 +1,11 @@
+# Dashboard Overview
+
+`/dashboard` loads data from `/dashboard?json=1` and shows:
+
+- Vault ID and current token balance
+- Last voice transcript and suggested `.idea.yaml`
+- Claude reflection output from `vault-prompts/<vault>/claude-reflection.json`
+- Button to run `reflect-vault` via the server
+- Voice recorder and upload field to preview voice agents
+
+All information is read from the local `vault/` directory so you can monitor sync status and exported agents.

--- a/docs/WEB_UI.md
+++ b/docs/WEB_UI.md
@@ -1,0 +1,12 @@
+# Web UI
+
+Run `make serve` and open `/start` to pair your local vault. The dashboard lives in the `frontend/` folder and is served by `boot-server.js`.
+
+Pages:
+- `/start` – shows a QR code and Begin button to create or pair a vault.
+- `/dashboard` – displays vault ID, token balance, recent voice transcripts and suggested ideas. You can record audio or upload a file for voice preview.
+- `/upload` – drag and drop chat logs, idea files or code archives. The files are processed by existing upload agents and trigger vault reflection.
+- `/vault/<id>` – JSON view of vault usage and logs.
+- `/marketplace` – preview exported ideas with a Remix link.
+
+These pages are mobile friendly and use Tailwind CSS.

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-xl font-bold mb-4">Dashboard</h1>
+  <div id="info" class="mb-4"></div>
+  <div id="voice" class="mb-4"></div>
+  <div id="idea" class="mb-4"></div>
+  <div id="reflection" class="mb-4"></div>
+  <button id="reflect" class="px-2 py-1 bg-blue-500 text-white rounded">Reflect vault</button>
+  <hr class="my-4">
+  <div>
+    <h2 class="font-semibold">Voice Preview</h2>
+    <button id="record" class="px-2 py-1 bg-green-500 text-white rounded mr-2">Record</button>
+    <input type="file" id="voiceFile" accept="audio/*" class="mt-2" />
+  </div>
+  <pre id="log" class="mt-2"></pre>
+<script src="dashboard.js"></script>
+</body>
+</html>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -1,0 +1,42 @@
+async function load(){
+  const res = await fetch('/dashboard?json=1');
+  const data = await res.json();
+  document.getElementById('info').innerHTML = `<p>Vault: <b>${data.user}</b></p><p>Tokens: ${data.tokens}</p>`;
+  if(data.transcript) document.getElementById('voice').textContent = 'Last voice: '+data.transcript;
+  if(data.idea) document.getElementById('idea').innerHTML = `<pre>${JSON.stringify(data.idea,null,2)}</pre>`;
+  fetch(`/vault-prompts/${data.user}/claude-reflection.json`).then(r=>r.ok?r.json():null).then(d=>{ if(d) document.getElementById('reflection').innerHTML=`<h2 class='font-semibold'>Claude Reflection</h2><pre>${d.response||''}</pre>`; });
+}
+
+async function reflect(){
+  const res = await fetch('/audit-vault',{method:'POST'});
+  document.getElementById('log').textContent = await res.text();
+}
+
+document.getElementById('reflect').onclick = reflect;
+
+const voiceInput = document.getElementById('voiceFile');
+voiceInput.onchange = e => uploadVoice(e.target.files[0]);
+
+let recorder, chunks=[];
+const recordBtn = document.getElementById('record');
+recordBtn.onclick = async () => {
+  if(recorder && recorder.state==='recording'){ recorder.stop(); recordBtn.textContent='Record'; return; }
+  chunks=[];
+  const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+  recorder = new MediaRecorder(stream);
+  recorder.ondataavailable = e => chunks.push(e.data);
+  recorder.onstop = () => {
+    const blob = new Blob(chunks,{type:'audio/wav'});
+    uploadVoice(blob);
+  };
+  recorder.start();
+  recordBtn.textContent='Stop';
+};
+
+function uploadVoice(file){
+  const fd = new FormData();
+  fd.append('file', file, 'voice.wav');
+  fetch('/voice-upload',{method:'POST',body:fd}).then(r=>r.text()).then(t=>{document.getElementById('log').textContent=t; load();});
+}
+
+load();

--- a/frontend/marketplace.html
+++ b/frontend/marketplace.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Marketplace</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-xl font-bold mb-4">Marketplace</h1>
+  <table class="table-auto border" id="table"></table>
+<script>
+fetch('/marketplace?json=1').then(r=>r.json()).then(list=>{
+  const rows = list.map(i=>`<tr><td class='border px-2'>${i.title}</td><td class='border px-2'>${i.creator}</td><td class='border px-2'><a class='text-blue-500' href='/marketplace/remix?slug=${i.slug}'>Remix</a></td></tr>`).join('');
+  document.getElementById('table').innerHTML = `<tr><th class='border px-2'>Idea</th><th class='border px-2'>Creator</th><th class='border px-2'></th></tr>`+rows;
+});
+</script>
+</body>
+</html>

--- a/frontend/start.html
+++ b/frontend/start.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Begin</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4 text-center">
+  <h1 class="text-xl font-bold mb-4">Start</h1>
+  <div id="qr" class="mb-4"></div>
+  <p id="vault" class="mb-4"></p>
+  <button id="begin" class="px-4 py-2 bg-blue-500 text-white rounded">Begin</button>
+<script>
+async function load(){
+  const res = await fetch('/start?json=1');
+  const data = await res.json();
+  document.getElementById('vault').textContent = 'Vault: '+data.user;
+  document.getElementById('qr').innerHTML = '<img class="mx-auto" src="'+data.qr+'"/>';
+  document.getElementById('begin').onclick = () => location.href = '/dashboard?user='+data.user;
+}
+load();
+</script>
+</body>
+</html>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Upload</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-xl font-bold mb-4">Upload Files</h1>
+  <div id="drop" class="border-2 border-dashed p-8 text-center mb-4">Drop files here</div>
+  <input type="file" id="file" multiple class="mb-4" />
+  <pre id="log"></pre>
+<script src="upload.js"></script>
+</body>
+</html>

--- a/frontend/upload.js
+++ b/frontend/upload.js
@@ -1,0 +1,16 @@
+const drop = document.getElementById('drop');
+const input = document.getElementById('file');
+
+function handle(files){
+  const fd = new FormData();
+  for(const f of files) fd.append('files', f);
+  fetch('/upload', { method:'POST', body: fd })
+    .then(r=>r.json())
+    .then(d=>{ document.getElementById('log').textContent = JSON.stringify(d,null,2); })
+    .catch(e=>{ document.getElementById('log').textContent = e.toString(); });
+}
+
+drop.addEventListener('dragover', e=>{ e.preventDefault(); drop.classList.add('bg-gray-100'); });
+drop.addEventListener('dragleave', ()=> drop.classList.remove('bg-gray-100'));
+drop.addEventListener('drop', e=>{ e.preventDefault(); drop.classList.remove('bg-gray-100'); handle(e.dataTransfer.files); });
+input.onchange = e => handle(e.target.files);

--- a/frontend/vault.html
+++ b/frontend/vault.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Vault Viewer</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-xl font-bold mb-4">Vault</h1>
+  <pre id="data"></pre>
+<script>
+const user = location.pathname.split('/').pop();
+fetch(`/vault/${user}?json=1`).then(r=>r.json()).then(d=>{
+  document.getElementById('data').textContent = JSON.stringify(d,null,2);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add static frontend pages for `/start`, `/dashboard`, `/upload`, `/marketplace`, and vault viewer
- serve frontend, vault and log directories from `boot-server.js`
- expose JSON endpoints for `/start` and replace HTML templates with static files
- add simple Tailwind-based dashboard with voice recording and upload support
- document new UI in `docs/WEB_UI.md` and `docs/DASHBOARD_OVERVIEW.md`
- provide make targets `dashboard`, `vault-ui`, and `reflect-ui`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848888cbd788327905088a4484fdf0b