### PR TITLE
Add launch and reflection stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,3 +243,37 @@ node scripts/router/vault-router.js --user $(user) --idea $(idea)
 
 unlock-agent:
 node scripts/vault-cli.js deposit $(user) $(amount)
+
+# New runtime utilities
+launch:
+./launch-agent.sh
+
+record:
+node scripts/agent/voice-reflector.js record
+
+play-last-voice:
+node scripts/agent/voice-reflector.js play
+
+whisper-idea:
+node scripts/agent/voice-reflector.js whisper
+
+mirror:
+node scripts/agent/memory-mirror.js
+
+unlock:
+node scripts/payments/stripe-hook.js unlock
+
+pay:
+node scripts/payments/stripe-hook.js pay
+
+refer:
+node scripts/payments/stripe-hook.js refer
+
+reflect:
+node scripts/agent/memory-mirror.js
+
+whisper:
+node scripts/agent/voice-reflector.js whisper
+
+remix:
+node scripts/agent/memory-mirror.js

--- a/docs/LAUNCH_AGENT.md
+++ b/docs/LAUNCH_AGENT.md
@@ -1,0 +1,4 @@
+# Launch Agent
+
+Run `make launch` or execute `./launch-agent.sh` to install dependencies, pair a device and start the server.
+The script prompts for a vault name and opens `/start` in your browser once the server is running.

--- a/docs/MEMORY_MIRROR.md
+++ b/docs/MEMORY_MIRROR.md
@@ -1,0 +1,4 @@
+# Memory Mirror
+
+`make mirror` runs a stubbed memory reflection loop that would normally process `.mp4` recordings or vault lineage.
+It is designed to update `.idea.yaml` files after each loop.

--- a/docs/VAULT_UNLOCK.md
+++ b/docs/VAULT_UNLOCK.md
@@ -1,0 +1,12 @@
+# Vault Unlock
+
+The runtime includes a simple payment and referral stub.
+Before accessing Claude or Cal features you must run one of:
+
+```
+make pay      # process a $1 payment
+make refer    # create a referral token
+make unlock   # unlock using an existing token
+```
+
+These commands call `scripts/payments/stripe-hook.js` which can be extended with real Stripe integration.

--- a/docs/VOICE_REFLECTION.md
+++ b/docs/VOICE_REFLECTION.md
@@ -1,0 +1,11 @@
+# Voice Reflection
+
+The voice reflector allows quick idea capture using a microphone.
+
+```
+make record        # record from your default device
+make play-last-voice
+make whisper-idea  # transcribe the last recording
+```
+
+These commands are stubs and can be extended with Whisper or Claude for full transcription.

--- a/launch-agent.sh
+++ b/launch-agent.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# launch-agent.sh - install and run ai-kernel
+set -e
+REPO_URL=${1:-https://github.com/yourorg/ai-kernel.git}
+TARGET_DIR=${2:-ai-kernel}
+
+if [ ! -d "$TARGET_DIR" ]; then
+  git clone "$REPO_URL" "$TARGET_DIR"
+fi
+cd "$TARGET_DIR"
+
+npm install >/dev/null 2>&1
+
+VAULT_DEFAULT=$(openssl rand -hex 4 2>/dev/null || echo "vault")
+read -p "Vault name [$VAULT_DEFAULT]: " VAULT_NAME
+VAULT_NAME=${VAULT_NAME:-$VAULT_DEFAULT}
+
+node scripts/server/pair-device.js "$VAULT_NAME" || true
+
+make serve &
+PID=$!
+
+if command -v xdg-open >/dev/null; then
+  xdg-open http://localhost:3000/start
+elif command -v open >/dev/null; then
+  open http://localhost:3000/start
+fi
+
+wait $PID
+

--- a/scripts/agent/memory-mirror.js
+++ b/scripts/agent/memory-mirror.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// Memory mirror loop stub
+
+async function main() {
+  console.log('Running memory mirror... (stub)');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/agent/voice-reflector.js
+++ b/scripts/agent/voice-reflector.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Voice reflector stub
+const fs = require('fs');
+const path = require('path');
+
+function usage() {
+  console.log('Usage: node voice-reflector.js <command>');
+  console.log('Commands: record, play, whisper');
+}
+
+async function main() {
+  const cmd = process.argv[2];
+  if (!cmd) return usage();
+
+  switch (cmd) {
+    case 'record':
+      console.log('Recording voice... (stub)');
+      break;
+    case 'play':
+      console.log('Playing last voice... (stub)');
+      break;
+    case 'whisper':
+      console.log('Running whisper transcription... (stub)');
+      break;
+    default:
+      usage();
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/payments/stripe-hook.js
+++ b/scripts/payments/stripe-hook.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// Stripe payment stub for unlock and referral
+
+const cmd = process.argv[2];
+
+switch (cmd) {
+  case 'pay':
+    console.log('Processing payment... (stub)');
+    break;
+  case 'refer':
+    console.log('Creating referral token... (stub)');
+    break;
+  case 'unlock':
+    console.log('Unlocking vault... (stub)');
+    break;
+  default:
+    console.log('Usage: node stripe-hook.js <pay|refer|unlock>');
+}


### PR DESCRIPTION
## Summary
- add `launch-agent.sh` installer script
- stub out voice reflection and memory mirror scripts
- add payment/referral stub
- document new runtime features
- hook up new make targets for launch, voice, payments and reflection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68489627e90c8327940067f35dd6ac56