### PR TITLE
Add onboarding funnel scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vault-restore:
         node scripts/vault-restore.js $(file)
 
 voice:
-        node scripts/agent/claude-voice.js $(file) $(user)
+        node scripts/onboarding/voice-onboard.js $(file) $(user)
 
 enrich-ideas:
         node scripts/daemon/idea-enrichment.js
@@ -261,19 +261,31 @@ mirror:
 node scripts/agent/memory-mirror.js
 
 unlock:
-node scripts/payments/stripe-hook.js unlock
+	node scripts/onboarding/devkit-unlock.js $(user)
 
 pay:
 node scripts/payments/stripe-hook.js pay
 
 refer:
-node scripts/payments/stripe-hook.js refer
+	node scripts/onboarding/referral.js $(referrer) $(new)
 
 reflect:
-node scripts/agent/memory-mirror.js
+	node scripts/onboarding/seed-idea.js $(user)
 
 whisper:
 node scripts/agent/voice-reflector.js whisper
 
 remix:
 node scripts/agent/memory-mirror.js
+
+digest:
+	node scripts/onboarding/daily-digest.js $(user)
+
+set-theme:
+	node scripts/onboarding/theme-manager.js set $(name) $(user)
+
+buy-theme:
+	node scripts/onboarding/theme-manager.js buy $(name) $(user)
+
+devkit:
+	node scripts/devkit/build-devkit.js $(user)

--- a/docs/DEVKIT_EXPORT.md
+++ b/docs/DEVKIT_EXPORT.md
@@ -1,0 +1,9 @@
+# DevKit Export
+
+Run `make devkit user=<id>` to bundle the current vault as a zip file. If your vault has fewer than one token you will see:
+
+```
+This vault is sealed. You can unlock it for $1 or with a referral.
+```
+
+Unlock by depositing a token with `make unlock user=<id>` or by sharing a referral code via `make refer`.

--- a/docs/IMAGINEER_ONBOARDING.md
+++ b/docs/IMAGINEER_ONBOARDING.md
@@ -1,0 +1,5 @@
+# Imagineer Onboarding
+
+Run `make voice file=<wav>` to start the Whisper based welcome flow. The script creates a new vault, stores `voice.mp3` and writes `onboarding.md`.
+
+Follow with `make reflect user=<id>` to seed a minimal `.idea.yaml` and a `reflection.md` summary.

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,0 +1,5 @@
+# Narrator Themes
+
+Theme files live in `themes/<name>.json`. Each vault can set a theme with `make set-theme name=<theme> user=<id>`.
+
+Use `make buy-theme name=<theme> user=<id>` to spend a token and unlock new styles.

--- a/scripts/devkit/build-devkit.js
+++ b/scripts/devkit/build-devkit.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const { exportDevkit } = require('./export-devkit');
+const { render } = require('../agent/vault-visualizer');
+const { reflect } = require('../agents/reflection-agent');
+
+async function main(){
+  const user = process.argv[2];
+  if(!user){ console.log('Usage: build-devkit.js <user>'); process.exit(1); }
+  reflect(user);
+  render(user);
+  const zip = exportDevkit(user);
+  console.log(zip);
+}
+
+if(require.main===module){
+  main();
+}

--- a/scripts/onboarding/daily-digest.js
+++ b/scripts/onboarding/daily-digest.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath } = require('../core/user-vault');
+const { run } = require('../cron/nightly-reflection');
+const { speak } = require('../agent/glyph-agent');
+
+async function main(){
+  const user = process.argv[2];
+  if(!user){ console.log('Usage: daily-digest.js <user>'); process.exit(1); }
+  ensureUser(user);
+  await run(user);
+  const vault = getVaultPath(user);
+  fs.writeFileSync(path.join(vault,'remix-candidates.json'), JSON.stringify([{ id: Date.now() }],null,2));
+  speak(user, 'I found a forgotten sketch from last week. Want to review it together?');
+}
+
+if(require.main===module){
+  main().catch(err=>{ console.error(err); process.exit(1); });
+}

--- a/scripts/onboarding/devkit-unlock.js
+++ b/scripts/onboarding/devkit-unlock.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const { ensureUser, loadTokens, saveTokens } = require('../core/user-vault');
+const { exportDevkit } = require('../devkit/export-devkit');
+
+function main(){
+  const user = process.argv[2];
+  if(!user){ console.log('Usage: devkit-unlock.js <user>'); process.exit(1); }
+  ensureUser(user);
+  let tokens = loadTokens(user);
+  if(tokens < 1){
+    console.log('This vault is sealed. You can unlock it for $1 or with a referral.');
+    return;
+  }
+  saveTokens(user, tokens-1);
+  const zip = exportDevkit(user);
+  console.log('DevKit zipped:', zip);
+}
+
+if(require.main===module){
+  main();
+}

--- a/scripts/onboarding/referral.js
+++ b/scripts/onboarding/referral.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { ensureUser, getVaultPath, loadTokens, saveTokens } = require('../core/user-vault');
+
+function main(){
+  const referrer = process.argv[2];
+  const invitee = process.argv[3];
+  if(!referrer || !invitee){
+    console.log('Usage: referral.js <referrer> <invitee>');
+    process.exit(1);
+  }
+  ensureUser(referrer);
+  ensureUser(invitee);
+  const refFile = path.join(getVaultPath(invitee),'referral.json');
+  fs.writeFileSync(refFile, JSON.stringify({ referrer, timestamp:new Date().toISOString() },null,2));
+  saveTokens(referrer, loadTokens(referrer)+1);
+  saveTokens(invitee, loadTokens(invitee)+1);
+  console.log('Referral accepted. You\'ve been granted export access. Want to share this with someone else?');
+}
+
+if(require.main===module){
+  main();
+}

--- a/scripts/onboarding/seed-idea.js
+++ b/scripts/onboarding/seed-idea.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { ensureUser, getVaultPath } = require('../core/user-vault');
+const { speak } = require('../agent/glyph-agent');
+
+function summarize(text){
+  return text.split('\n')[0].slice(0,60);
+}
+
+function main(){
+  const user = process.argv[2];
+  if(!user){ console.log('Usage: seed-idea.js <user>'); process.exit(1); }
+  ensureUser(user);
+  const vault = getVaultPath(user);
+  const onboard = path.join(vault,'onboarding.md');
+  if(!fs.existsSync(onboard)) throw new Error('onboarding.md not found');
+  const text = fs.readFileSync(onboard,'utf8');
+  const summary = summarize(text);
+  fs.writeFileSync(path.join(vault,'reflection.md'), summary);
+  const idea = { name: summary, description: text };
+  fs.writeFileSync(path.join(vault,'seed.idea.yaml'), yaml.dump(idea));
+  speak(user, 'This sounds like an idea worth building. Want me to prep a DevKit?');
+}
+
+if(require.main===module){
+  try { main(); } catch(err){ console.error(err); process.exit(1); }
+}

--- a/scripts/onboarding/theme-manager.js
+++ b/scripts/onboarding/theme-manager.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const { loadTheme, saveTheme } = require('../agent/glyph-agent');
+const { ensureUser } = require('../core/user-vault');
+const fs = require('fs');
+const path = require('path');
+const { loadTokens, saveTokens, getVaultPath } = require('../core/user-vault');
+
+const cmd = process.argv[2];
+const name = process.argv[3];
+const user = process.argv[4] || 'demo';
+
+ensureUser(user);
+
+switch(cmd){
+  case 'set':
+    if(!name){ console.log('Usage: theme-manager.js set <theme> [user]'); process.exit(1); }
+    const file = path.join('themes', `${name}.json`);
+    if(fs.existsSync(file)) {
+      const data = JSON.parse(fs.readFileSync(file,'utf8'));
+      saveTheme(user, data);
+      console.log('Theme set to', name);
+    } else {
+      console.log('Theme not found');
+    }
+    break;
+  case 'buy':
+    if(!name){ console.log('Usage: theme-manager.js buy <theme> [user]'); process.exit(1); }
+    const cost = 1;
+    let tokens = loadTokens(user);
+    if(tokens < cost){ console.log('Need 1 token to buy theme'); return; }
+    tokens -= cost; saveTokens(user, tokens);
+    fs.copyFileSync(path.join('themes',`${name}.json`), path.join(getVaultPath(user),`owned-${name}.json`));
+    console.log('Theme purchased:', name);
+    break;
+  default:
+    console.log('Usage: theme-manager.js <set|buy> <theme> [user]');
+}

--- a/scripts/onboarding/voice-onboard.js
+++ b/scripts/onboarding/voice-onboard.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+const { ensureUser, getVaultPath } = require('../core/user-vault');
+const { transcribe } = require('../agent/claude-voice');
+const { speak } = require('../agent/glyph-agent');
+
+async function main() {
+  const file = process.argv[2];
+  if (!file) {
+    console.log('Usage: voice-onboard.js <voice-file> [user]');
+    process.exit(1);
+  }
+  let user = process.argv[3] || randomUUID();
+  ensureUser(user);
+  const vault = getVaultPath(user);
+  fs.mkdirSync(vault, { recursive: true });
+  const dest = path.join(vault, 'voice.mp3');
+  fs.copyFileSync(file, dest);
+  const text = await transcribe(file);
+  fs.writeFileSync(path.join(vault, 'onboarding.md'), text);
+  speak(user, "Got it. Welcome. I've created a vault for you. Let's take a look.");
+  console.log(user);
+}
+
+if (require.main === module) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/themes/cosmic-future.json
+++ b/themes/cosmic-future.json
@@ -1,0 +1,8 @@
+{
+  "narrator": "Zara",
+  "companion": "Nova",
+  "voice": "synth",
+  "tts": "on",
+  "color": "#f0f",
+  "style": "Cosmic"
+}

--- a/themes/default.json
+++ b/themes/default.json
@@ -1,0 +1,8 @@
+{
+  "narrator": "Cal Riven",
+  "companion": "Arty",
+  "voice": "default",
+  "tts": "on",
+  "color": "#0ff",
+  "style": "Typewriter"
+}

--- a/usage.json
+++ b/usage.json
@@ -3,6 +3,6 @@
     "agent": "localAgent",
     "provider": "local",
     "tokens": 0,
-    "timestamp": "2025-06-10T19:12:42.134Z"
+    "timestamp": "2025-06-10T20:50:01.657Z"
   }
 ]


### PR DESCRIPTION
## Summary
- implement onboarding voice flow and devkit utilities
- add theme manager and referral scripts
- add docs for onboarding, themes, and devkit export
- wire up new commands in Makefile and sample themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684899136a2c832791eec2faf650cb70